### PR TITLE
Fix incorrect 1.8 item names

### DIFF
--- a/src/main/java/me/xhawk87/CreateYourOwnMenus/commands/menu/MenuGrabCommand.java
+++ b/src/main/java/me/xhawk87/CreateYourOwnMenus/commands/menu/MenuGrabCommand.java
@@ -34,22 +34,72 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.lang.reflect.Field;
 
 /**
  * @author XHawk87
  */
 public class MenuGrabCommand implements IMenuCommand {
 
-    private static final Set<Material> boots = EnumSet.of(Material.LEATHER_BOOTS, Material.CHAINMAIL_BOOTS,
-            Material.IRON_BOOTS, Material.GOLDEN_BOOTS, Material.DIAMOND_BOOTS);
-    private static final Set<Material> leggings = EnumSet.of(Material.LEATHER_LEGGINGS, Material.CHAINMAIL_LEGGINGS,
-            Material.IRON_LEGGINGS, Material.GOLDEN_LEGGINGS, Material.DIAMOND_LEGGINGS);
-    private static final Set<Material> chestplates = EnumSet.of(Material.LEATHER_CHESTPLATE,
-            Material.CHAINMAIL_CHESTPLATE, Material.IRON_CHESTPLATE, Material.GOLDEN_CHESTPLATE,
-            Material.DIAMOND_CHESTPLATE);
-    private static final Set<Material> helmets = EnumSet.of(Material.LEATHER_HELMET, Material.CHAINMAIL_HELMET,
-            Material.IRON_HELMET, Material.GOLDEN_HELMET, Material.DIAMOND_HELMET, Material.PUMPKIN,
-            Material.SKELETON_SKULL, Material.WITHER_SKELETON_SKULL);
+
+    private static Material getMaterial(String... names) {
+        for (String name : names) {
+            try {
+                Field field = Material.class.getField(name);
+                return (Material) field.get(null);
+            } catch (NoSuchFieldException | IllegalAccessException ignored) {
+            }
+        }
+        return null;
+    }
+
+    private static Set<Material> createMaterialSet(Material... materials) {
+        Set<Material> materialSet = EnumSet.noneOf(Material.class);
+        for (Material material : materials) {
+            if (material != null) {
+                materialSet.add(material);
+            }
+        }
+        return materialSet;
+    }
+
+    private static final Set<Material> boots = createMaterialSet(
+            Material.LEATHER_BOOTS,
+            Material.CHAINMAIL_BOOTS,
+            Material.IRON_BOOTS,
+            getMaterial("GOLD_BOOTS", "GOLDEN_BOOTS"),
+            Material.DIAMOND_BOOTS
+    );
+
+    private static final Set<Material> leggings = createMaterialSet(
+            Material.LEATHER_LEGGINGS,
+            Material.CHAINMAIL_LEGGINGS,
+            Material.IRON_LEGGINGS,
+            getMaterial("GOLD_LEGGINGS", "GOLDEN_LEGGINGS"),
+            Material.DIAMOND_LEGGINGS
+    );
+
+    private static final Set<Material> chestplates = createMaterialSet(
+            Material.LEATHER_CHESTPLATE,
+            Material.CHAINMAIL_CHESTPLATE,
+            Material.IRON_CHESTPLATE,
+            getMaterial("GOLD_CHESTPLATE", "GOLDEN_CHESTPLATE"),
+            Material.DIAMOND_CHESTPLATE
+    );
+
+    private static final Set<Material> helmets = createMaterialSet(
+            Material.LEATHER_HELMET,
+            Material.CHAINMAIL_HELMET,
+            Material.IRON_HELMET,
+            getMaterial("GOLD_HELMET", "GOLDEN_HELMET"),
+            Material.DIAMOND_HELMET,
+            Material.PUMPKIN,
+            getMaterial("SKULL_ITEM", "SKELETON_SKULL"),
+            getMaterial("WITHER_SKULL", "WITHER_SKELETON_SKULL")
+    );
+
+
+
     private CreateYourOwnMenus plugin;
 
     public MenuGrabCommand(CreateYourOwnMenus plugin) {

--- a/src/main/java/me/xhawk87/CreateYourOwnMenus/listeners/MenuListener.java
+++ b/src/main/java/me/xhawk87/CreateYourOwnMenus/listeners/MenuListener.java
@@ -93,7 +93,7 @@ public class MenuListener implements Listener {
             // First check if the clicked slot is a locked inventory slot
             int rawSlot = event.getRawSlot();
             int numInTop = event.getView().getTopInventory().getSize();
-            if ((rawSlot >= numInTop) && rawSlot != 45) { {
+            if ((rawSlot >= numInTop) && rawSlot != 45) {
                 // The clicked slot is the player's inventory
                 int slot = event.getSlot();
                 if (player.hasPermission("cyom.slot.lock." + slot)


### PR DESCRIPTION
- Fixes #43 

Previously, loading the Plugin on an Version before the new material ids were introduced (such as the still widely used version 1.8.9), the plugin would create a `NoSuchFieldException` for `GOLDEN_BOOTS`, `GOLDEN_LEGGINGS`, `GOLDEN_CHESTPLATE` and `GOLDEN_HELMET` aswell as `SKELETON_SKULL` and `WITHER_SKELETON_SKULL`.

The solution was to catch the `NoSuchFieldException` and then pass on the old material ids.